### PR TITLE
fix bug with map min-max distance display

### DIFF
--- a/wp-content/themes/pwtc/single-scheduled_rides.php
+++ b/wp-content/themes/pwtc/single-scheduled_rides.php
@@ -43,11 +43,17 @@ if(get_field('attach_map')) {
     if($length == $maxLength) {
         $maxLength = null;
     }
+    $data['terrain'] = array_unique($terrain);
+    $data['length'] = $length;
+    $data['max_length'] = $maxLength;
+    $data['maps'] = $maps;    
 }
-$data['terrain'] = isset($terrain) ? array_unique($terrain) : get_field('terrain');
-$data['length'] = isset($length) ? $length : get_field('length');
-$data['max_length'] = isset($maxLength) ? $maxLength : get_field('max_length');
-$data['maps'] = isset($maps) ? $maps : false;
+else {
+    $data['terrain'] = get_field('terrain');
+    $data['length'] = get_field('length');
+    $data['max_length'] = get_field('max_length');
+    $data['maps'] = false;     
+}
 
 // Fetch the ride's description, break it into tokens delemited by whitespace
 // and look for strings that start with "http://" or "https://". Convert those


### PR DESCRIPTION
Bug reported by user:
The when the max distance on the map is left blank, and a published ride posting originially had a min + max distance range... then when the published ride is updated with a map a few days later, the max distance for the ride remains at max value (it used to be wiped out an the ride would only show the min distance as shown on the map).