### PR TITLE
Change ride view button labels

### DIFF
--- a/wp-content/themes/pwtc/templates/partials/ride-calendarlink.html.twig
+++ b/wp-content/themes/pwtc/templates/partials/ride-calendarlink.html.twig
@@ -1,1 +1,1 @@
-<a href="/scheduled_rides/?month={{ date|date('Y-m') }}" class="dark button"><i class="fa fa-chevron-left"></i> Return to calendar</a>
+<a href="/scheduled_rides/?month={{ date|date('Y-m') }}" class="dark button"><i class="fa fa-chevron-left"></i> Back to Rides</a>

--- a/wp-content/themes/pwtc/templates/ride-details.html.twig
+++ b/wp-content/themes/pwtc/templates/ride-details.html.twig
@@ -51,7 +51,7 @@
                 </div>
                 <div>
                     {% include 'partials/ride-calendarlink.html.twig' with {date: SP.ACF.get_field('date')} only %}
-                    <a href="{{ current_url }}?feed=ical-ride" class="dark button"><i class="fa fa-download"></i> Export Ride</a>
+                    <a href="{{ current_url }}?feed=ical-ride" class="dark button"><i class="fa fa-download"></i> Add to Calendar</a>
                     {% if user_can_cancel %}
                         {% if SP.ACF.get_field('is_canceled') %}
                             <a href="{{ current_url }}?canceled=0" class="success button"><i class="fa fa-calendar-check-o"></i> Allow Ride</a>


### PR DESCRIPTION
A user suggested that "Add to Calendar" is a better label than "Export Rides". Also changed "Return to calendar" to "Back to Rides" to prevent confusion between the ride calendar and a user's smartphone calendar app.